### PR TITLE
feat: 添加品牌设置功能到账户设置页面

### DIFF
--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -159,5 +159,4 @@ export const api = {
   ) => apiRequest<T>(endpoint, { ...config, method: "PATCH", body }),
 };
 
-export { api };
 export default api;

--- a/src/services/auth/index.ts
+++ b/src/services/auth/index.ts
@@ -47,6 +47,13 @@ export const authApi = {
 
   // 刷新token
   refresh: () => api.post("/api/auth/refresh"),
+
+  // 获取当前品牌
+  getCurrentBrand: () => api.get("/api/auth/current-brand"),
+
+  // 更新当前品牌
+  updateCurrentBrand: (brandData: { brand_id: string }) =>
+    api.put("/api/auth/current-brand", brandData),
 };
 
 // 认证相关的工具函数

--- a/src/services/brand/index.ts
+++ b/src/services/brand/index.ts
@@ -5,6 +5,17 @@
 import { api } from "@/lib/api-client";
 import { Brand, CreateBrandRequest, PaginatedResponse } from "@/lib/types";
 
+// 品牌列表响应类型（匹配后端API）
+interface BrandListResponse {
+  data: Brand[];
+  meta: {
+    page: number;
+    page_size: number;
+    total: number;
+    total_pages: number;
+  };
+}
+
 // 品牌API方法
 export const brandApi = {
   // 创建品牌
@@ -20,48 +31,35 @@ export const brandApi = {
   }) => {
     const searchParams = new URLSearchParams();
     if (params?.page) searchParams.append("page", params.page.toString());
-    if (params?.page_size) searchParams.append("page_size", params.page_size.toString());
+    if (params?.page_size)
+      searchParams.append("page_size", params.page_size.toString());
     if (params?.search) searchParams.append("search", params.search);
     if (params?.status) searchParams.append("status", params.status);
-    
+
     const queryString = searchParams.toString();
     const endpoint = queryString ? `/api/brands?${queryString}` : "/api/brands";
-    
-    return api.get<PaginatedResponse<Brand>>(endpoint);
+
+    return api.get<BrandListResponse>(endpoint);
   },
 
   // 获取单个品牌详情
-  get: (brandId: string) =>
-    api.get<Brand>(`/api/brands/${brandId}`),
+  get: (brandId: string) => api.get<Brand>(`/api/brands/${brandId}`),
 
   // 更新品牌
   update: (brandId: string, brandData: Partial<CreateBrandRequest>) =>
     api.put<Brand>(`/api/brands/${brandId}`, brandData),
 
   // 删除品牌
-  delete: (brandId: string) =>
-    api.delete(`/api/brands/${brandId}`),
+  delete: (brandId: string) => api.delete(`/api/brands/${brandId}`),
 
   // 验证品牌域名
   verifyDomain: (domain: string) =>
-    api.post<{ verified: boolean; message: string }>("/api/brands/verify-domain", { domain }),
-
-  // 获取用户的品牌列表
-  getUserBrands: () =>
-    api.get<Brand[]>("/api/brands/user"),
-
-  // 设置默认品牌
-  setDefault: (brandId: string) =>
-    api.put(`/api/brands/${brandId}/set-default`),
-
-  // 获取品牌统计信息
-  getStats: (brandId: string) =>
-    api.get<{
-      total_searches: number;
-      total_responses: number;
-      avg_visibility_score: number;
-      last_search_date: string;
-    }>(`/api/brands/${brandId}/stats`),
+    api.post<{ verified: boolean; message: string }>(
+      "/api/brands/verify-domain",
+      {
+        domain,
+      }
+    ),
 };
 
 // 品牌相关的工具函数
@@ -85,17 +83,20 @@ export const brandUtils = {
     if (!domain || domain.trim().length === 0) {
       return { valid: false, message: "域名不能为空" };
     }
-    
+
     // 移除协议前缀
-    const cleanDomain = domain.replace(/^https?:\/\//, "").replace(/^www\./, "");
-    
+    const cleanDomain = domain
+      .replace(/^https?:\/\//, "")
+      .replace(/^www\./, "");
+
     // 基本域名格式验证
-    const domainRegex = /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
-    
+    const domainRegex =
+      /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+
     if (!domainRegex.test(cleanDomain)) {
       return { valid: false, message: "请输入有效的域名格式" };
     }
-    
+
     return { valid: true };
   },
 
@@ -109,21 +110,26 @@ export const brandUtils = {
   },
 
   // 验证关键词
-  validateKeywords: (keywords: string): { valid: boolean; message?: string } => {
+  validateKeywords: (
+    keywords: string
+  ): { valid: boolean; message?: string } => {
     if (!keywords || keywords.trim().length === 0) {
       return { valid: false, message: "关键词不能为空" };
     }
-    
-    const keywordList = keywords.split(/[,\n]/).map(k => k.trim()).filter(k => k.length > 0);
-    
+
+    const keywordList = keywords
+      .split(/[,\n]/)
+      .map((k) => k.trim())
+      .filter((k) => k.length > 0);
+
     if (keywordList.length === 0) {
       return { valid: false, message: "请至少输入一个关键词" };
     }
-    
+
     if (keywordList.length > 100) {
       return { valid: false, message: "关键词数量不能超过100个" };
     }
-    
+
     return { valid: true };
   },
 
@@ -131,8 +137,8 @@ export const brandUtils = {
   formatKeywords: (keywords: string): string[] => {
     return keywords
       .split(/[,\n]/)
-      .map(k => k.trim())
-      .filter(k => k.length > 0);
+      .map((k) => k.trim())
+      .filter((k) => k.length > 0);
   },
 
   // 获取品牌状态显示文本


### PR DESCRIPTION
- 在账户设置中新增品牌设置子标签
- 实现获取当前品牌和更新当前品牌的API调用
- 添加品牌列表分页显示，每页3个品牌
- 支持品牌切换功能，过滤当前品牌避免重复显示
- 添加加载更多品牌和刷新功能
- 优化用户体验，显示当前品牌信息和可选品牌列表